### PR TITLE
rtx_thread: Exit early if Idle thread create fails

### DIFF
--- a/Source/rtx_thread.c
+++ b/Source/rtx_thread.c
@@ -2409,6 +2409,9 @@ bool_t osRtxThreadStartup (void) {
   osRtxInfo.thread.idle = osRtxThreadId(
     svcRtxThreadNew(osRtxIdleThread, NULL, osRtxConfig.idle_thread_attr)
   );
+  if (osRtxInfo.thread.idle == NULL) {
+    return FALSE;
+  }
 
   // Create Timer Thread
   if (osRtxConfig.timer_setup != NULL) {


### PR DESCRIPTION
The result of Idle thread creation is not checked. There could be a scenario where the idle thread creation failed but the Startup function does not report it. Fix it by checking the ThreadNew step for Idle is
successful.