### PR TITLE
Revert "rtx_thread: Exit early if Idle thread create fails (#60)"

### DIFF
--- a/Source/rtx_thread.c
+++ b/Source/rtx_thread.c
@@ -2409,9 +2409,6 @@ bool_t osRtxThreadStartup (void) {
   osRtxInfo.thread.idle = osRtxThreadId(
     svcRtxThreadNew(osRtxIdleThread, NULL, osRtxConfig.idle_thread_attr)
   );
-  if (osRtxInfo.thread.idle == NULL) {
-    return FALSE;
-  }
 
   // Create Timer Thread
   if (osRtxConfig.timer_setup != NULL) {


### PR DESCRIPTION
Revert PR no.60 for the following reasons:
 - there haven't been test cases to test that path
 - there was in the past such check, but then removed
 - the project is working towards 100% code coverage thus, for the above, it does not help in that direction

See https://github.com/ARM-software/CMSIS-RTX/pull/60 for further details.

This reverts commit b1c75fc3114b85bda23e5207a877b31fe5a74360.