### PR TITLE
Extend action Fetch pre-built RTX libraries to use latest libraries a.o.

### DIFF
--- a/.ci/vcpkg-configuration.json
+++ b/.ci/vcpkg-configuration.json
@@ -1,19 +1,19 @@
 {
- "registries": [
-  {
-   "name": "arm",
-   "kind": "artifact",
-   "location": "https://artifacts.tools.arm.com/vcpkg-registry"
+  "registries": [
+    {
+      "name": "arm",
+      "kind": "artifact",
+      "location": "https://artifacts.tools.arm.com/vcpkg-registry"
+    }
+  ],
+  "requires": {
+    "arm:tools/open-cmsis-pack/cmsis-toolbox": "2.14.1",
+    "arm:compilers/arm/armclang": "6.24.0",
+    "arm:compilers/arm/arm-none-eabi-gcc": "15.3.1",
+    "arm:compilers/arm/llvm-embedded": "22.1.0",
+    "arm:compilers/iar/cxarm": "9.70.4",
+    "arm:models/arm/avh-fvp": "11.30.29",
+    "arm:tools/kitware/cmake": "4.3.3",
+    "arm:tools/ninja-build/ninja": "1.13.2"
   }
- ],
- "requires": {
-  "arm:tools/open-cmsis-pack/cmsis-toolbox": "2.12.0",
-  "arm:compilers/arm/armclang": "6.24.0",
-  "arm:models/arm/avh-fvp": "11.30.29",
-  "arm:compilers/arm/arm-none-eabi-gcc": "14.3.1",
-  "arm:tools/kitware/cmake": "3.31.5",
-  "arm:compilers/arm/llvm-embedded": "21.1.1",
-  "arm:tools/ninja-build/ninja": "1.12.1",
-  "arm:compilers/iar/cxarm": "9.70.2"
- }
 }

--- a/.github/workflows/cmsis_rv2.yml
+++ b/.github/workflows/cmsis_rv2.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v7
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Python requirements
         run: |
@@ -68,13 +68,13 @@ jobs:
           path: /home/runner/.cache/arm/packs
 
       - name: Setup vcpkg environment
-        uses: ARM-software/cmsis-actions/vcpkg@v1.1
+        uses: ARM-software/cmsis-actions/vcpkg@v1
         with:
           config: ./CMSIS-RTOS2_Validation/.ci/vcpkg-configuration.json
           cache: "-${{ matrix.compiler }}-${{ matrix.variant }}"
 
       - name: Activate Arm tool license
-        uses: ARM-software/cmsis-actions/armlm@v1.1
+        uses: ARM-software/cmsis-actions/armlm@v1
         with:
           code: ${{ env.ARM_UBL_ACTIVATION_CODE }}
 
@@ -93,7 +93,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          ./CMSIS-RTX/Library/fetch_libs.sh
+          if [[ "$GITHUB_REPOSITORY" == "ARM-software/CMSIS-RTX" ]]; then
+            ./CMSIS-RTX/Library/fetch_libs.sh
+          else
+            ./CMSIS-RTX/Library/fetch_libs.sh --latest
+          fi
 
       - uses: ammaraskar/gcc-problem-matcher@master
         if: matrix.compiler == 'GCC'

--- a/.github/workflows/libs.yml
+++ b/.github/workflows/libs.yml
@@ -38,12 +38,12 @@ jobs:
           path: /home/runner/.cache/arm/packs
 
       - name: Setup build environment
-        uses: ARM-software/cmsis-actions/vcpkg@v1.3
+        uses: ARM-software/cmsis-actions/vcpkg@v1
         with:
           config: ./Library/vcpkg-configuration.json
 
       - name: Activate Arm tool license
-        uses: ARM-software/cmsis-actions/armlm@v1.3
+        uses: ARM-software/cmsis-actions/armlm@v1
         with:
           code: ${{ env.ARM_UBL_ACTIVATION_CODE }}
 

--- a/Library/vcpkg-configuration.json
+++ b/Library/vcpkg-configuration.json
@@ -7,12 +7,12 @@
     }
   ],
   "requires": {
-    "arm:tools/kitware/cmake": "3.31.5",
-    "arm:tools/ninja-build/ninja": "1.13.2",
+    "arm:tools/open-cmsis-pack/cmsis-toolbox": "2.14.1",
     "arm:compilers/arm/armclang": "6.24.0",
-    "arm:compilers/arm/arm-none-eabi-gcc": "14.3.1",
+    "arm:compilers/arm/arm-none-eabi-gcc": "15.3.1",
     "arm:compilers/arm/llvm-embedded": "21.1.1",
-    "arm:tools/open-cmsis-pack/cmsis-toolbox": "2.12.0",
-    "arm:compilers/iar/cxarm": "9.70.2"
+    "arm:compilers/iar/cxarm": "9.70.4",
+    "arm:tools/kitware/cmake": "4.3.3",
+    "arm:tools/ninja-build/ninja": "1.13.2"
   }
 }


### PR DESCRIPTION
- Extend action Fetch pre-built RTX libraries to use latest libraries build in the fork. 
- Added avh-fvp models to the vcpkg-configurtation which are needed for the execute action. 
- Pin avh-fvp version to 11.30.29. The model version 11.31.28 uses a Python 3.11 runtime which is packaged with a build-time prefix. That directory existed only on Arm’s build system. It does not exist on the GitHub runner, so Python cannot load its essential encodings module and aborts before the simulation completes.